### PR TITLE
Splitfile bugfixes

### DIFF
--- a/CLI.php
+++ b/CLI.php
@@ -322,7 +322,7 @@ Usage:
   scisr rename-method OwningClassName oldMethodName newMethodName [options] [files]
   scisr rename-file old/file_name new/dir/new_file_name [options] [files]
   scisr rename-class-file OldName NewName [options] [files]
-  scisr split-class-file OutputDir [options] [files]
+  scisr split-class-files OutputDir [options] [files]
 
 [files] is any number of files and/or directories to be searched and modified.
 

--- a/ChangeRegistry.php
+++ b/ChangeRegistry.php
@@ -64,7 +64,6 @@ class Scisr_ChangeRegistry
      * @param boolean $tentative true if we want to overwrite the file
      */
     public function createFile($filename, $content, $tentative = false) {
-
       $file = new Scisr_CreateFile($filename, $content);
       $this->setFile($file);
     

--- a/Operations/RenameClass.php
+++ b/Operations/RenameClass.php
@@ -45,8 +45,7 @@ class Scisr_Operations_RenameClass extends Scisr_Operations_AbstractChangeOperat
             }
         } else if ($tokens[$stackPtr]['code'] == T_PAAMAYIM_NEKUDOTAYIM) {
             $classNamePtr = $phpcsFile->findPrevious(T_STRING, $stackPtr);
-            $this->checkClassNamePtr($classNamePtr, $phpcsFile);
-        } else {
+            $this->checkClassNamePtr($classNamePtr, $phpcsFile);} else {
             $classNamePtr = $phpcsFile->findNext(T_STRING, $stackPtr);
             $this->checkClassNamePtr($classNamePtr, $phpcsFile);
         }

--- a/Operations/SplitClassFile.php
+++ b/Operations/SplitClassFile.php
@@ -42,7 +42,7 @@ class Scisr_Operations_SplitClassFile extends Scisr_Operations_AbstractChangeOpe
         $className = $tokens[$classNamePtr]['content'];
 
         //print "Got class $className from: $startPointer -> $classPtr -   $endPointer \n";
-        $content = array();
+        $content = array("<?php\n");
         for ($i = $startPointer; $i < $endPointer ; $i++) {
           $content[] = $tokens[$i]['content'];
         }
@@ -54,6 +54,17 @@ class Scisr_Operations_SplitClassFile extends Scisr_Operations_AbstractChangeOpe
     private function getStartPointer($stackPtr, $phpcsFile) {
         $tokens = $phpcsFile->getTokens();
 
+        for ($i = $stackPtr ; $i > 0 ; $i--) {
+          if (! in_array($tokens[$i-1]['code'], PHP_CodeSniffer_Tokens::$emptyTokens)) {
+            //print "Next not code {$tokens[$i-1]['content']}, returning pointer $i -> $stackPtr\n";
+            // remove whitespace on top of class
+            while ($tokens[$i]['code'] == T_WHITESPACE && in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$emptyTokens)) {
+              $i++;
+            }
+            return $i;
+          }
+        }
+        throw new Exception("Should not end here!");
         $start = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$commentTokens, $stackPtr,0, false );
 
         return ($start && $start < $stackPtr ) ? $start  : $stackPtr;

--- a/tests/SplitClassFilesTest.php
+++ b/tests/SplitClassFilesTest.php
@@ -54,8 +54,8 @@ EOL;
         //$this->compareFile($this->test_file, $original);
         foreach ($expected as $filename => $content) {
             $actual = file_get_contents($this->outputDir . "/" . $filename . ".php" );
-            //         var_dump(array('ac' =>$actual, 'o' => $content));
-            $this->assertEquals($actual, $content);
+                     var_dump(array('ac' =>$actual, 'o' => $content));
+            $this->assertEquals($actual, "<?php\n" . $content);
         }
     }
     public function testSplitFilesTwoClasses() {
@@ -64,6 +64,18 @@ EOL;
             'Baz' => $this->baz . "\n", 'Bar' => $this->bar . "\n" ); 
         $this->splitAndCompare($orig, $expected);
     }
+    public function testSplitFilesTwoClassesNotCommentBetween() {
+        $orig = "{$this->start}
+{$this->comment}
+{$this->baz}\n
+{$this->bar}";
+        $expected = array(
+            'Baz' => $this->comment . "\n" . $this->baz . "\n", 
+            'Bar' => $this->bar . "\n" 
+            ); 
+        $this->splitAndCompare($orig, $expected);
+    }
+
 
 
     public function testSplitFilesTwoClassesWithComments() {


### PR DESCRIPTION
It is interesting to see what bugs show up when you start using a tool properly.  

I saw you did some whitespace changes. If this doesn't apply cleanly I'll look into it (forgot to rebase). 
1. Add <?php at the start of each file
2. Add correct command name to the cli help message
3. Fix an issue with getting the complete class comments included in the new file
