### PR TITLE
Make the unit tests run with a current PHPUnit version

### DIFF
--- a/CreateFile.php
+++ b/CreateFile.php
@@ -17,7 +17,7 @@ class Scisr_CreateFile extends Scisr_File {
     public function process($mode)
     {
         if ($mode != ScisrRunner::MODE_AGGRESSIVE && file_exists($this->filename)) {
-            throw new Exception("Cannot overwrite {$this->filename} in timid mode!");
+            throw new RuntimeException("Cannot overwrite {$this->filename} in timid mode!");
         }
         file_put_contents($this->filename, $this->content);
     }

--- a/File.php
+++ b/File.php
@@ -196,13 +196,13 @@ class Scisr_File
                 $success = mkdir($dir, 0775, true);
                 if (!$success) {
                     $err = "Could not create new directory ($dir)";
-                    throw new Exception($err);
+                    throw new RuntimeException($err);
                 }
             }
             $success = rename($this->filename, $this->_newName);
             if (!$success) {
                 $err = "Could not rename file ($this->filename => $this->_newName)";
-                throw new Exception($err);
+                throw new RuntimeException($err);
             }
         }
         return (count($this->changes) > 0);
@@ -301,7 +301,7 @@ class Scisr_File
                 // I don't expect this to ever happen unless a developer makes a mistake,
                 // so we'll just abort messily
                 $err = "We've encountered conflicting edit requests. Cannot continue.";
-                throw new Exception($err);
+                throw new RuntimeException($err);
             }
 
         }

--- a/Operations/RenameFile.php
+++ b/Operations/RenameFile.php
@@ -63,7 +63,7 @@ class Scisr_Operations_RenameFile extends Scisr_Operations_AbstractFileOperation
     {
         if (Scisr_File::isExplicitlyRelative($actualPath)) {
             if ($currDir === false) {
-                throw new Exception('You provided a relative path without a current dir!');
+                throw new LogicException('You provided a relative path without a current dir!');
             }
             $actualPath = Scisr_File::getAbsolutePath($actualPath, $currDir);
             // Add a trailing slash if it's not there

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -135,7 +135,7 @@ EOL;
         $f = new Scisr_File($this->test_file);
         $f->addEdit(2, 4, 3, 'Replacement', false);
         $f->addEdit(2, 6, 2, 'Foo', false);
-        $this->setExpectedException('Exception');
+        $this->setExpectedException('RuntimeException');
         $f->process(ScisrRunner::MODE_CONSERVATIVE);
     }
 
@@ -150,7 +150,7 @@ EOL;
         $f->addEdit(2, 1, 2, '/**/', false);
         $f->addEdit(2, 4, 3, 'Replacement', false);
         $f->addEdit(2, 6, 2, 'Foo', false);
-        $this->setExpectedException('Exception');
+        $this->setExpectedException('RuntimeException');
         $f->process(ScisrRunner::MODE_CONSERVATIVE);
     }
 

--- a/tests/RenameFileTest.php
+++ b/tests/RenameFileTest.php
@@ -159,7 +159,7 @@ class RenameFileTest extends Scisr_SingleFileTest
     }
 
     public function testMatchPathsNoCurrDirError() {
-        $this->setExpectedException('Exception');
+        $this->setExpectedException('LogicException');
         $this->assertSame('DUMMY', Scisr_Operations_RenameFile::matchPaths('/foo/bar', './relative/path'));
     }
 

--- a/tests/Scisr_TestCase.php
+++ b/tests/Scisr_TestCase.php
@@ -1,5 +1,4 @@
 <?php
-require_once 'PHPUnit/Framework.php';
 require_once '../ScisrRunner.php';
 
 class Scisr_TestCase extends PHPUnit_Framework_TestCase

--- a/tests/SplitClassFilesTest.php
+++ b/tests/SplitClassFilesTest.php
@@ -121,9 +121,9 @@ EOL;
 
     }
     /**
-     * @expectedException Exception
+     * @expectedException RuntimeException
      */
-    public function testOverwriteExistingThrowsExceptionIfNotaggressive() {
+    public function testOverwriteExistingThrowsExceptionIfNotAggressive() {
         $orig = "{$this->start}
 {$this->function}
 {$this->comment}


### PR DESCRIPTION
Expecting the bare Exception class is no longer allowed in PHPUnit
and using it eliminates fine-grained catch use.

Thus some Exception uses are replaced by RuntimException and
LogicException with this change.
